### PR TITLE
Update the namespace for the PSR-4 autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
 	"license": "MIT",
 	"autoload": {
 		"psr-4": {
-			"philcook\\GTMetrixClient\\": "src/"
+			"Entrecore\\GTMetrixClient\\": "src/"
 		}
 	},
 	"require": {


### PR DESCRIPTION
When using PSR-4 autoloading, the namespace should be based on the *code* namespace (e.g. "Entrecore\GTMetrixClient"), not the package name ("philcook/gtmetrix"). As it stands now, the generated autoloader looks like:

```php
'philcook\\GTMetrixClient\\' => array($vendorDir . '/philcook/gtmetrix/src'),
```

When the desired line would be:

```php
'Entrecore\\GTMetrixClient\\' => array($vendorDir . '/philcook/gtmetrix/src'),
```